### PR TITLE
Add path to canSetCookies when it is initially set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ function checkClientHints() {
 	if (!navigator.cookieEnabled) return;
 
 	// set a short-lived cookie to make sure we can set cookies
-	document.cookie = "canSetCookies=1; Max-Age=60; SameSite=Lax";
+	document.cookie = "canSetCookies=1; Max-Age=60; SameSite=Lax; path=/";
 	const canSetCookies = document.cookie.includes("canSetCookies=1");
 	document.cookie = "canSetCookies=; Max-Age=-1; path=/";
 	if (!canSetCookies) return;


### PR DESCRIPTION
This stops canSetCookies from being set in every route and never being cleared by the script.