### PR TITLE
Fix the identified issue

### DIFF
--- a/src/color-scheme.ts
+++ b/src/color-scheme.ts
@@ -21,7 +21,7 @@ export function subscribeToSchemeChange(
 	const schemaMatch = window.matchMedia('(prefers-color-scheme: dark)')
 	function handleThemeChange() {
 		const value = schemaMatch.matches ? 'dark' : 'light'
-		document.cookie = `${cookieName}=${value}; Max-Age=31536000; Path=/`
+		document.cookie = `${cookieName}=${value}; Max-Age=31536000; SameSite=Lax; Path=/`
 		subscriber(value)
 	}
 	schemaMatch.addEventListener('change', handleThemeChange)

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ function checkClientHints() {
 		.join(',\n')}
 	];
 	for (const hint of hints) {
-		document.cookie = encodeURIComponent(hint.name) + '=' + encodeURIComponent(hint.actual) + '; Max-Age=31536000; path=/';
+		document.cookie = encodeURIComponent(hint.name) + '=' + encodeURIComponent(hint.actual) + '; Max-Age=31536000; SameSite=Lax; path=/';
 		if (decodeURIComponent(hint.value) !== hint.actual) {
 			cookieChanged = true;
 		}

--- a/src/reduced-motion.ts
+++ b/src/reduced-motion.ts
@@ -21,7 +21,7 @@ export function subscribeToMotionChange(
 	const motionMatch = window.matchMedia('(prefers-reduced-motion: reduce)')
 	function handleMotionChange() {
 		const value = motionMatch.matches ? 'reduce' : 'no-preference'
-		document.cookie = `${cookieName}=${value}; Max-Age=31536000; Path=/`
+		document.cookie = `${cookieName}=${value}; Max-Age=31536000; SameSite=Lax; Path=/`
 		subscriber(value)
 	}
 	motionMatch.addEventListener('change', handleMotionChange)


### PR DESCRIPTION
Add `SameSite=Lax` to permanent cookies to resolve Firefox hydration errors.

The permanent cookies (with `Max-Age=31536000`) were missing the `SameSite` attribute, which caused hydration errors in Firefox-based browsers. Adding `SameSite=Lax` aligns with existing temporary cookie implementations and modern browser security standards, providing CSRF protection while allowing normal functionality.